### PR TITLE
feat: Initial implementation of discord2pushover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,196 @@
-# discord-to-pushover
+# discord2pushover
+
+## Overview
+
+`discord2pushover` is a command-line application for Linux that monitors Discord messages in channels your bot is part of. Based on a flexible ruleset defined in a YAML configuration file, it can send notifications to [Pushover](https://pushover.net/). It's designed for foreground operation, making it suitable for integration with systemd or container environments.
+
+Key functionalities include:
+- Watching for new messages in Discord channels.
+- Sending customizable Pushover notifications.
+- Handling Pushover's emergency-priority notifications, including tracking acknowledgment status and reacting on Discord once acknowledged.
+- Allowing emoji reactions on Discord messages when rules are matched.
+- Supporting environment variable substitution within the configuration file for sensitive data.
+
+## Features
+
+- **Discord Message Monitoring**: Listens to messages in real-time.
+- **Pushover Notifications**: Sends messages to specified Pushover users or groups.
+- **Configurable Rules Engine**: Define detailed rules to filter messages based on:
+    - Channel ID
+    - Message reactions (emojis)
+    - Bot @mentions
+    - Specific user/role @mentions
+    - Keywords in message content
+- **Emergency Alert Handling**:
+    - Supports Pushover's emergency priority (Priority 2).
+    - Tracks acknowledgment status of emergency alerts via Pushover API.
+    - Reacts on the original Discord message with a configurable emoji when an emergency alert is acknowledged.
+    - Handles expiry of emergency alerts.
+- **Discord Reactions**: Can automatically add a configurable emoji reaction to a Discord message when a rule matches.
+- **Environment Variable Substitution**: Securely pass sensitive data (like tokens) into the configuration file using environment variables (e.g., `$DISCORD_TOKEN`, `${PUSHOVER_APP_KEY}`).
+- **Graceful Shutdown**: Handles SIGINT/SIGTERM signals for clean shutdown.
+- **Version Information**: Provides build version via `-version` flag.
+
+## Configuration (`discord2pushover.yaml`)
+
+The application looks for its configuration file in the following order:
+1.  Path specified by the `-c` command-line flag (e.g., `-c /path/to/your/config.yaml`).
+2.  `discord2pushover.yaml` in the current working directory.
+3.  `discord2pushover.yml` in the current working directory.
+
+If no configuration file is found, the application will print an error and exit.
+
+### Global Settings
+
+These settings are at the top level of your YAML file:
+
+-   `discordToken`: (string, required) Your Discord Bot Token. **Important**: This must be a Bot token, not a user token. Example: `"YOUR_DISCORD_BOT_TOKEN"`
+-   `pushoverUserKey`: (string, required for some test scenarios, but typically per-rule) Your personal Pushover User Key. While it can be global, most notifications will use a `pushoverDestination` defined in a rule's actions. Example: `"YOUR_PUSHOVER_USER_KEY"`
+-   `pushoverAppKey`: (string, required) Your Pushover Application API Token. You need to register an application on the Pushover site to get this. Example: `"YOUR_PUSHOVER_APP_TOKEN"`
+
+### Environment Variable Substitution
+
+You can embed environment variables in your YAML configuration file. The application will replace placeholders like `"$VAR_NAME"` or `"${VAR_NAME}"` with the actual value of the `VAR_NAME` environment variable at startup. If an environment variable is not set, the placeholder string will remain as is (as of current implementation, though this might change to error out or use an empty string in strict mode later).
+
+Example:
+```yaml
+discordToken: "$BOT_TOKEN"
+pushoverAppKey: "${MY_PUSHOVER_APP_KEY}"
+```
+
+### Rules
+
+The `rules` section is a list of rule objects. Rules are evaluated from top to bottom for each incoming Discord message. The first rule that matches all its conditions will have its actions triggered, and **no further rules will be processed for that message.**
+
+Each `rule` object has the following structure:
+
+-   `name`: (string, optional) A descriptive name for the rule. This is useful for logging and debugging.
+    Example: `"Critical Error Alert"`
+-   `conditions`: (object, required) An object defining the conditions that must ALL be met for this rule to trigger. If a condition field is omitted (e.g., `channelID` is not specified), that condition is considered to be met (i.e., it doesn't filter).
+    -   `channelID`: (string, optional) The specific Discord channel ID to monitor. If omitted, the rule applies to messages from any channel the bot has access to.
+        Example: `"123456789012345678"`
+    -   `messageHasEmoji`: ([]string, optional) A list of emoji names (Unicode emoji character or custom emoji name without colons). The condition is met if the Discord message has a reaction with ANY of these emojis.
+        Example: `["🔥", "alert_emoji"]`
+    -   `reactToAtMention`: (boolean, optional) If `true`, the message must @mention the bot itself (either directly or via @everyone/@here). Defaults to `false` if omitted.
+        Example: `true`
+    -   `specificMentions`: ([]string, optional) A list of Discord User IDs or Role IDs. The condition is met if the message mentions ANY of these users or roles.
+        Example: `["U123ABCDEFG", "R098ZYXWVU"]`
+    -   `contentIncludes`: ([]string, optional) A list of keywords. ALL keywords in this list must be present in the message content for the condition to be met. The check is case-insensitive.
+        Example: `["error", "database connection failed"]`
+-   `actions`: (object, required) Defines the actions to take if all conditions are met.
+    -   `pushoverDestination`: (string, required) The Pushover user key or group key to send the notification to.
+        Example: `"uMyPushoverUserKey"` or `"gMyPushoverGroupKey"`
+    -   `priority`: (integer, required) The Pushover notification priority. Valid values are:
+        -   `-2`: Lowest
+        -   `-1`: Low
+        -   `0`: Normal
+        -   `1`: High
+        -   `2`: Emergency (requires `emergency` block below)
+        Example: `1`
+    -   `reactionEmoji`: (string, optional) A Unicode emoji or a custom Discord emoji name (without colons) to react with on the original Discord message.
+        Example: `"✅"` or `"custom_reaction"`
+    -   `emergency`: (object, optional) This block is **required if and only if `priority` is `2` (Emergency)**.
+        -   `ackEmoji`: (string, required for emergency) The emoji to react with on the Discord message once the Pushover emergency notification has been acknowledged by a user.
+            Example: `"👍"`
+        -   `expire`: (integer, required for emergency) The Pushover `expire` parameter in seconds. This is the duration for which Pushover will keep trying to send the notification until it's acknowledged or expires. Maximum is 10800 seconds (3 hours), but Pushover recommends values up to 3600 (1 hour) for their retry/expire mechanism. This also dictates how long the bot will track the acknowledgement.
+            Example: `3600` (1 hour)
+        -   `retry`: (integer, required for emergency) The Pushover `retry` parameter in seconds. This defines how often Pushover should resend the notification within the `expire` period. Minimum is 30 seconds.
+            Example: `60` (resend every 60 seconds)
+
+### Example Configuration
+
+```yaml
+# Global settings
+discordToken: "$DISCORD_BOT_TOKEN" # Replaced by environment variable DISCORD_BOT_TOKEN
+# pushoverUserKey: "uYourGlobalPushoverUserKey" # Usually defined per rule in actions.pushoverDestination
+pushoverAppKey: "${PUSHOVER_APP_KEY}" # Replaced by environment variable PUSHOVER_APP_KEY
+
+rules:
+  - name: "Critical System Alert with Emoji"
+    conditions:
+      channelID: "123456789012345678" # Specific channel
+      messageHasEmoji: ["🔥", "sos"] # If message has 🔥 OR sos reaction
+      contentIncludes: ["critical", "system down"] # Must contain BOTH "critical" AND "system down"
+    actions:
+      pushoverDestination: "uYourPushoverUserKey"
+      priority: 2 # Emergency
+      reactionEmoji: "🚨" # Bot reacts with 🚨 on Discord
+      emergency:
+        ackEmoji: "✅" # Bot reacts with ✅ when Pushover alert is acknowledged
+        expire: 3600 # Pushover will retry for 1 hour; bot tracks for this long.
+        retry: 60    # Pushover retries every 60 seconds.
+
+  - name: "Mentions for Support Team"
+    conditions:
+      specificMentions: ["R98765432109876543"] # Specific role mention
+      # reactToAtMention: false (default)
+    actions:
+      pushoverDestination: "gSupportGroupKey" # Send to a Pushover group
+      priority: 1 # High
+      reactionEmoji: "🔔"
+
+  - name: "DB Error in Any Channel"
+    conditions:
+      contentIncludes: ["database error"] # Message must contain "database error"
+    actions:
+      pushoverDestination: "uDBAdminUserKey"
+      priority: 0 # Normal
+      reactionEmoji: "💾"
+
+  - name: "Bot Mention General"
+    conditions:
+      reactToAtMention: true # If bot is @mentioned
+    actions:
+      pushoverDestination: "uYourPushoverUserKey"
+      priority: 0
+      # No reactionEmoji for this rule
+```
+
+## Building
+
+To build the application, ensure you have Go installed (version 1.18 or later recommended).
+
+```bash
+go build .
+```
+This will create a `discord2pushover` executable in the current directory.
+
+## Running
+
+Execute the binary, optionally providing a path to your configuration file:
+
+```bash
+./discord2pushover -c /path/to/your/discord2pushover.yaml
+```
+
+If the configuration file is named `discord2pushover.yaml` or `discord2pushover.yml` and located in the same directory as the executable, you can run it without the `-c` flag:
+
+```bash
+./discord2pushover
+```
+
+### Required Discord Bot Permissions
+
+Ensure your Discord bot has the following permissions in the channels it needs to monitor and react in:
+-   **View Channels** (also known as Read Messages)
+-   **Read Message History**
+-   **Add Reactions**
+
+(Note: "Send Messages" permission is not strictly required for basic operation unless future features sending messages are added.)
+
+## Signal Handling
+
+The application listens for `SIGINT` (Ctrl+C) and `SIGTERM` signals. Upon receiving either of these, it will attempt to shut down gracefully by:
+1.  Stopping the emergency acknowledgment poller.
+2.  Closing the connection to Discord.
+3.  Exiting.
+
+## Version
+
+To print the version information (version, commit hash, build date), use the `-version` flag:
+
+```bash
+./discord2pushover -version
+```
+
+This information is embedded at build time if building from a Git repository.

--- a/config.go
+++ b/config.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the top-level configuration structure.
+type Config struct {
+	DiscordToken    string `yaml:"discordToken"`
+	PushoverUserKey string `yaml:"pushoverUserKey"`
+	PushoverAppKey  string `yaml:"pushoverAppKey"`
+	Rules           []Rule `yaml:"rules"`
+}
+
+// Rule defines a single rule for processing messages.
+type Rule struct {
+	Name       string         `yaml:"name"`
+	Conditions RuleConditions `yaml:"conditions"`
+	Actions    RuleActions    `yaml:"actions"`
+}
+
+// RuleConditions defines the conditions for a rule to match.
+type RuleConditions struct {
+	ChannelID        string   `yaml:"channelId"`
+	MessageHasEmoji  []string `yaml:"messageHasEmoji"`
+	ReactToAtMention bool     `yaml:"reactToAtMention"`
+	SpecificMentions []string `yaml:"specificMentions"`
+	ContentIncludes  []string `yaml:"contentIncludes"`
+}
+
+// RuleActions defines the actions to take when a rule matches.
+type RuleActions struct {
+	PushoverDestination string           `yaml:"pushoverDestination"`
+	Priority            int              `yaml:"priority"`
+	ReactionEmoji       string           `yaml:"reactionEmoji"`
+	Emergency           *EmergencyParams `yaml:"emergency,omitempty"`
+}
+
+// EmergencyParams defines parameters for Pushover emergency priority messages.
+type EmergencyParams struct {
+	AckEmoji string `yaml:"ackEmoji"`
+	Expire   int    `yaml:"expire"`
+	Retry    int    `yaml:"retry"`
+}
+
+// LoadConfig reads a YAML file from filePath, parses it into a Config struct,
+// and replaces environment variable placeholders.
+func LoadConfig(filePath string) (*Config, error) {
+	// Read the YAML file
+	log.Printf("Reading configuration file: %s", filePath)
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+	}
+
+	// Substitute environment variables
+	substitutedData := substituteEnvVars(data)
+
+	// Parse the YAML
+	var cfg Config
+	log.Println("Parsing YAML configuration...")
+	err = yaml.Unmarshal(substitutedData, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config file %s: %w", filePath, err)
+	}
+	log.Println("YAML configuration parsed successfully.")
+	return &cfg, nil
+}
+
+// substituteEnvVars replaces placeholders like $VAR_NAME or ${VAR_NAME} in the
+// input byte slice with corresponding environment variable values.
+func substituteEnvVars(data []byte) []byte {
+	s := string(data)
+	// Regex to find $VAR_NAME or ${VAR_NAME}
+	// It captures VAR_NAME in both cases
+	r := regexp.MustCompile(`\$(\{([A-Z_][A-Z0-9_]*)\}|([A-Z_][A-Z0-9_]*))`)
+
+	replacedString := r.ReplaceAllStringFunc(s, func(found string) string {
+		var varName string
+		if strings.HasPrefix(found, "${") && strings.HasSuffix(found, "}") {
+			varName = found[2 : len(found)-1]
+		} else {
+			varName = found[1:]
+		}
+
+		val, isSet := os.LookupEnv(varName)
+		if isSet {
+			log.Printf("Substituting environment variable '%s' with value (length %d).", varName, len(val))
+			// For security/privacy, don't log the actual value if it could be sensitive.
+			// If you need to debug specific values, you can temporarily log `val` itself.
+		} else {
+			log.Printf("Environment variable '%s' not set. Placeholder '%s' will remain.", varName, found)
+			return found // Leave placeholder if not set
+		}
+		return val
+	})
+	return []byte(replacedString)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/user/discord2pushover
+
+go 1.22.2
+
+require (
+	github.com/bwmarrin/discordgo v0.29.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gregdel/pushover v1.3.1 // indirect
+	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
+github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gregdel/pushover v1.3.1 h1:4bMLITOZ15+Zpi6qqoGqOPuVHCwSUvMCgVnN5Xhilfo=
+github.com/gregdel/pushover v1.3.1/go.mod h1:EcaO66Nn1StkpEm1iKtBTV3d2A16SoMsVER1PthX7to=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"flag"
+	"flag"
+	"fmt"
+	"log" // Added for more consistent logging
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// globalConfig holds the loaded application configuration.
+// It's used by various parts of the application, including event handlers.
+var globalConfig *Config
+
+// TrackedEmergencyMessage holds information about an emergency Pushover notification
+// that requires acknowledgment tracking.
+type TrackedEmergencyMessage struct {
+	DiscordMessageID string
+	DiscordChannelID string
+	PushoverReceiptID string
+	AckEmoji          string
+	ExpiryTime        time.Time
+}
+
+// trackedMessages stores emergency messages that are pending acknowledgment.
+// Keyed by PushoverReceiptID.
+var trackedMessages sync.Map
+
+var (
+	// Populated by go build
+	Version = "dev"
+	Commit  = "none"
+	Date    = "unknown"
+)
+
+func main() {
+	fmt.Printf("discord2pushover version %s, commit %s, built at %s\n", Version, Commit, Date)
+
+	configPath := flag.String("c", "", "Path to the configuration file (e.g., discord2pushover.yaml)")
+	versionFlag := flag.Bool("version", false, "Print version information and exit")
+	flag.Parse()
+
+	if *versionFlag {
+		// Version info already printed
+		os.Exit(0)
+	}
+
+	actualConfigPath := ""
+	if *configPath != "" {
+		if _, err := os.Stat(*configPath); err == nil {
+			actualConfigPath = *configPath
+		} else {
+			fmt.Printf("Error: Config file specified by -c flag not found: %s\n", *configPath)
+			os.Exit(1)
+		}
+	} else {
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Printf("Error getting current working directory: %v\n", err)
+			os.Exit(1)
+		}
+		defaultPathYaml := filepath.Join(cwd, "discord2pushover.yaml")
+		if _, err := os.Stat(defaultPathYaml); err == nil {
+			actualConfigPath = defaultPathYaml
+		} else {
+			defaultPathYml := filepath.Join(cwd, "discord2pushover.yml")
+			if _, err := os.Stat(defaultPathYml); err == nil {
+				actualConfigPath = defaultPathYml
+			}
+		}
+	}
+
+	if actualConfigPath == "" {
+		fmt.Println("Error: Configuration file not found.")
+		fmt.Println("Please specify a config file using the -c flag,")
+		fmt.Println("or place 'discord2pushover.yaml' or 'discord2pushover.yml' in the current directory.")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Loading configuration from: %s\n", actualConfigPath)
+	loadedConfig, err := LoadConfig(actualConfigPath) // Use a temporary variable
+	if err != nil {
+		fmt.Printf("Error loading configuration: %v\n", err)
+		os.Exit(1)
+	}
+	globalConfig = loadedConfig // Assign to the global variable
+
+	fmt.Printf("Configuration loaded successfully.\n") // Simplified output
+
+	if globalConfig.DiscordToken == "" {
+		fmt.Println("Error: DiscordToken is missing from the configuration.")
+		os.Exit(1)
+	}
+	if globalConfig.PushoverAppKey == "" {
+		fmt.Println("Error: PushoverAppKey is missing from the configuration.")
+		os.Exit(1)
+	}
+	// Note: PushoverUserKey (the destination) is per-rule, so not checked globally here.
+
+	log.Println("Connecting to Discord...")
+	dg, err := discordgo.New("Bot " + globalConfig.DiscordToken)
+	if err != nil {
+		log.Printf("Error creating Discord session: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Register the messageCreate func as a callback for MessageCreate events.
+	dg.AddHandler(messageCreate)
+
+	// We only care about receiving message events.
+	dg.Identify.Intents = discordgo.IntentsGuildMessages
+
+	// Open a websocket connection to Discord and begin listening.
+	err = dg.Open()
+	if err != nil {
+		log.Printf("Error opening connection to Discord: %v\n", err)
+		os.Exit(1)
+	}
+	log.Println("Discord session opened successfully.")
+
+	// Start polling for emergency acknowledgements
+	go PollEmergencyAcknowledgements(dg, globalConfig) // Logging for poller start is inside the function
+
+	log.Println("Bot is now running. Press CTRL-C to exit.")
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+	
+	receivedSignal := <-sc
+	log.Printf("Received signal: %v. Shutting down...", receivedSignal)
+
+	// Cleanly close down the Discord session.
+	log.Println("Closing Discord session...")
+	err = dg.Close()
+	if err != nil {
+		log.Printf("Error closing Discord session: %v", err)
+	} else {
+		log.Println("Discord session closed.")
+	}
+	log.Println("Exiting.")
+}
+
+// PollEmergencyAcknowledgements periodically checks Pushover for acknowledged emergency messages
+// and reacts on Discord if they are acknowledged.
+func PollEmergencyAcknowledgements(session *discordgo.Session, config *Config) {
+	if config == nil {
+		log.Println("PollEmergencyAcknowledgements: globalConfig is nil, cannot poll.")
+		return
+	}
+	if session == nil {
+		log.Println("PollEmergencyAcknowledgements: Discord session is nil, cannot poll.")
+		return
+	}
+
+	// How often to poll Pushover for receipt status
+	// Requirement: "every 5 seconds"
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	log.Println("Starting emergency acknowledgement polling (interval: 5s)...")
+
+	for range ticker.C {
+		trackedMessages.Range(func(key, value interface{}) bool {
+			receiptID := key.(string)
+			trackedMsg, ok := value.(TrackedEmergencyMessage)
+			if !ok {
+				log.Printf("Error: Could not cast value for receipt %s to TrackedEmergencyMessage", receiptID)
+				return true // continue iteration
+			}
+
+			// Check for expiry
+			if time.Now().After(trackedMsg.ExpiryTime) {
+				log.Printf("Emergency message (Receipt: %s, DiscordMsg: %s) expired without acknowledgement.",
+					receiptID, trackedMsg.DiscordMessageID)
+				trackedMessages.Delete(receiptID)
+				return true // continue iteration
+			}
+
+			// Check Pushover for acknowledgment
+			log.Printf("Polling Pushover for receipt: %s (DiscordMsg: %s)", receiptID, trackedMsg.DiscordMessageID)
+			isAcknowledged, err := CheckPushoverReceipt(config.PushoverAppKey, receiptID)
+			if err != nil {
+				log.Printf("Error checking Pushover receipt %s: %v", receiptID, err)
+				// Don't remove from map, try again next time unless it's a permanent error (not handled yet)
+				return true // continue iteration
+			}
+
+			if isAcknowledged {
+				log.Printf("Pushover emergency message (Receipt: %s, DiscordMsg: %s) was acknowledged!",
+					receiptID, trackedMsg.DiscordMessageID)
+
+				if trackedMsg.AckEmoji != "" {
+					errReact := session.MessageReactionAdd(trackedMsg.DiscordChannelID, trackedMsg.DiscordMessageID, trackedMsg.AckEmoji)
+					if errReact != nil {
+						log.Printf("Error adding AckEmoji '%s' to Discord message %s (channel %s): %v",
+							trackedMsg.AckEmoji, trackedMsg.DiscordMessageID, trackedMsg.DiscordChannelID, errReact)
+					} else {
+						log.Printf("Added AckEmoji '%s' to Discord message %s (channel %s).",
+							trackedMsg.AckEmoji, trackedMsg.DiscordMessageID, trackedMsg.DiscordChannelID)
+					}
+				}
+				trackedMessages.Delete(receiptID) // Remove from tracking
+			} else {
+				log.Printf("Pushover receipt %s (DiscordMsg: %s) not yet acknowledged.", receiptID, trackedMsg.DiscordMessageID)
+			}
+			return true // continue iteration
+		})
+	}
+}
+
+// messageCreate will be called (by the discordgo library) every time a new
+// message is created on any channel that the authenticated bot has access to.
+func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
+	// Ignore all messages created by the bot itself
+	if m.Author.ID == s.State.User.ID {
+		return
+	}
+
+	// Log the basic message info (can be removed or made more verbose later)
+	// fmt.Printf("Received message: ID=%s, AuthorID=%s, ChannelID=%s, Content='%s'\n", m.ID, m.Author.ID, m.ChannelID, m.Content)
+
+	// Process rules against the message
+	if globalConfig != nil {
+		ProcessRules(m, globalConfig, s)
+	} else {
+		// This should ideally not happen if main() ensures globalConfig is initialized.
+		fmt.Println("Error: globalConfig is nil in messageCreate. Rules cannot be processed.")
+	}
+}

--- a/pushover.go
+++ b/pushover.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/gregdel/pushover"
+)
+
+// SendPushoverNotification sends a notification via Pushover.
+// It returns the receipt ID if the message was an emergency priority and successfully sent, otherwise an empty string.
+func SendPushoverNotification(config *Config, ruleAction *RuleActions, messageContent string, discordMessageLink string) (string, error) {
+	if config.PushoverAppKey == "" {
+		return "", fmt.Errorf("pushover AppKey is missing from global config")
+	}
+	if ruleAction.PushoverDestination == "" {
+		return "", fmt.Errorf("pushoverDestination is missing from rule action")
+	}
+
+	log.Printf("Preparing Pushover notification for destination '%s' with app key '%s'", ruleAction.PushoverDestination, config.PushoverAppKey)
+
+	// Create a new Pushover app instance
+	app := pushover.New(config.PushoverAppKey)
+
+	// Create a new recipient
+	recipient := pushover.NewRecipient(ruleAction.PushoverDestination)
+
+	// Create the message
+	title := "Discord Notification" // Or make this configurable later
+	fullMessage := fmt.Sprintf("%s\n\nDiscord Link: %s", messageContent, discordMessageLink)
+	log.Printf("Pushover message content (first 50 chars): %.50s", fullMessage) // Log snippet of message
+	message := pushover.NewMessageWithTitle(fullMessage, title)
+
+	// Set priority
+	// Pushover library uses these constants:
+	// PriorityLowest, PriorityLow, PriorityNormal, PriorityHigh, PriorityEmergency
+	switch ruleAction.Priority {
+	case -2:
+		message.Priority = pushover.PriorityLowest
+	case -1:
+		message.Priority = pushover.PriorityLow
+	case 0: // Default to normal if 0 or not specified
+		message.Priority = pushover.PriorityNormal
+	case 1:
+		message.Priority = pushover.PriorityHigh
+	case 2:
+		message.Priority = pushover.PriorityEmergency
+		if ruleAction.Emergency != nil {
+			message.Retry = ruleAction.Emergency.Retry
+			message.Expire = ruleAction.Emergency.Expire
+			// The gregdel/pushover library doesn't seem to have an explicit field for emergency sound.
+			// Typically, the sound is tied to the client or priority.
+			// Some libraries might allow specifying a sound, but this one defaults to Pushover's behavior for emergency.
+		} else {
+			// This case should ideally be prevented by config validation,
+			// but as a fallback, send as high priority if emergency params are missing.
+			log.Printf("Warning: Rule action has emergency priority (2) but Emergency parameters are missing. Sending as High Priority for rule action affecting destination %s.", ruleAction.PushoverDestination)
+			message.Priority = pushover.PriorityHigh
+		}
+	default:
+		log.Printf("Warning: Unknown priority %d specified for destination %s, defaulting to Normal Priority.", ruleAction.Priority, ruleAction.PushoverDestination)
+		message.Priority = pushover.PriorityNormal
+	}
+	log.Printf("Set Pushover priority to %d for destination %s.", message.Priority, ruleAction.PushoverDestination)
+
+	// Send the message
+	log.Printf("Sending Pushover notification to %s...", ruleAction.PushoverDestination)
+	resp, err := app.SendMessage(message, recipient)
+	if err != nil {
+		log.Printf("Error sending Pushover notification to %s: %v", ruleAction.PushoverDestination, err)
+		return "", fmt.Errorf("failed to send Pushover notification: %w", err)
+	}
+
+	if resp.Status != 1 {
+		log.Printf("Pushover API returned non-success status (%d) for destination %s. Errors: %v", resp.Status, ruleAction.PushoverDestination, resp.Errors)
+		return "", fmt.Errorf("pushover API error for destination %s: status %d, errors: %v", ruleAction.PushoverDestination, resp.Status, resp.Errors)
+	}
+
+	log.Printf("Pushover notification sent successfully to %s. Message ID: %s", ruleAction.PushoverDestination, resp.ID)
+
+	if message.Priority == pushover.PriorityEmergency {
+		log.Printf("Emergency notification sent, Pushover receipt ID: %s for destination %s", resp.Receipt, ruleAction.PushoverDestination)
+		return resp.Receipt, nil
+	}
+
+	return "", nil
+}
+
+// CheckPushoverReceipt checks the status of a Pushover emergency notification receipt.
+func CheckPushoverReceipt(appKey string, receiptID string) (isAcknowledged bool, err error) {
+	if appKey == "" {
+		return false, fmt.Errorf("appKey is missing for checking Pushover receipt %s", receiptID)
+	}
+	if receiptID == "" {
+		return false, fmt.Errorf("receiptID is missing for checking Pushover receipt with appKey %s", appKey)
+	}
+	// log.Printf("Checking Pushover receipt status for ID: %s with appKey: %s", receiptID, appKey) // Too verbose for every 5s poll
+
+	// The gregdel/pushover library's App struct holds the token.
+	// However, GetReceipt is a function in the pushover package, not a method on App.
+	// It requires the app token (which is our appKey) and receiptID.
+	// pushover.GetReceipt(token, receipt string) (*ReceiptDetails, error)
+	
+	// Note: The library's `pushover.New(appKey)` creates an `App` instance,
+	// but `GetReceipt` is a package-level function that takes the token directly.
+	// So, we don't need to instantiate an `App` here if we only use `GetReceipt`.
+	// However, the `token` parameter for `GetReceipt` is indeed the Application's API token.
+
+	details, err := pushover.GetReceipt(appKey, receiptID)
+	if err != nil {
+		// Check for specific Pushover API errors if necessary, e.g., receipt not found might be a specific error code.
+		// For now, just return the error.
+		return false, fmt.Errorf("failed to get Pushover receipt details for %s: %w", receiptID, err)
+	}
+
+	// According to Pushover API docs:
+	// acknowledged: 1 if acknowledged, 0 otherwise
+	// acknowledged_by: user key of the user that acknowledged
+	// acknowledged_at: UNIX timestamp of acknowledgement time
+	// last_delivered_at: UNIX timestamp of when the notification was last sent (for retrying notifications)
+	// expired: 1 if notification has expired, 0 otherwise
+	// expires_at: UNIX timestamp of when the notification will expire
+	// called_back: 1 if a callback URL was called, 0 otherwise
+	// called_back_at: UNIX timestamp of callback time
+
+	// The library's ReceiptDetails struct has:
+	// type ReceiptDetails struct {
+	// 	 Status          int    `json:"status"`
+	// 	 Acknowledged    int    `json:"acknowledged"` // This is what we need
+	// 	 AcknowledgedBy  string `json:"acknowledged_by"`
+	// 	 AcknowledgedAt  int    `json:"acknowledged_at"`
+	// 	 LastDeliveredAt int    `json:"last_delivered_at"`
+	// 	 Expired         int    `json:"expired"`
+	// 	 ExpiresAt       int    `json:"expires_at"`
+	// 	 CalledBack      int    `json:"called_back"`
+	// 	 CalledBackAt    int    `json:"called_back_at"`
+	// 	 Request         string `json:"request"`
+	// 	 Errors          Errors `json:"errors"`
+	// }
+	// We need to check `details.Acknowledged == 1`.
+
+	return details.Acknowledged == 1, nil
+}

--- a/rules.go
+++ b/rules.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// ProcessRules iterates through the configured rules and processes the first one that matches.
+func ProcessRules(message *discordgo.MessageCreate, config *Config, session *discordgo.Session) {
+	log.Printf("Processing rules for message ID %s (user: %s, channel: %s)", message.ID, message.Author.Username, message.ChannelID)
+	for i, rule := range config.Rules {
+		ruleNameLog := rule.Name
+		if ruleNameLog == "" {
+			ruleNameLog = fmt.Sprintf("unnamed_rule_%d", i+1)
+		}
+		log.Printf("Evaluating rule #%d: '%s' for message ID %s", i+1, ruleNameLog, message.ID)
+
+		conditionsMet := checkRuleConditions(message, &rule.Conditions, session, ruleNameLog)
+		if conditionsMet {
+			log.Printf("Rule #%d ('%s') MATCHED for message ID %s.", i+1, ruleNameLog, message.ID)
+			// Construct Discord message link
+			var discordMessageURL string
+			if message.GuildID != "" {
+				discordMessageURL = fmt.Sprintf("https://discord.com/channels/%s/%s/%s", message.GuildID, message.ChannelID, message.ID)
+			} else {
+				discordMessageURL = fmt.Sprintf("https://discord.com/channels/@me/%s/%s", message.ChannelID, message.ID)
+			}
+
+			// Trigger actions
+			log.Printf("Triggering actions for matched rule '%s' on message ID %s", ruleNameLog, message.ID)
+			receiptID, err := SendPushoverNotification(config, &rule.Actions, message.Content, discordMessageURL)
+			if err != nil {
+				log.Printf("Error sending Pushover notification for rule '%s' (message ID %s): %v", ruleNameLog, message.ID, err)
+			} else {
+				log.Printf("Pushover notification sent for rule '%s' (message ID %s). Receipt ID (if emergency): '%s'", ruleNameLog, message.ID, receiptID)
+
+				// Handle standard reaction emoji for the rule, regardless of priority
+				if rule.Actions.ReactionEmoji != "" {
+					log.Printf("Attempting to add reaction emoji '%s' for rule '%s' to message %s", rule.Actions.ReactionEmoji, ruleNameLog, message.ID)
+					errReact := session.MessageReactionAdd(message.ChannelID, message.ID, rule.Actions.ReactionEmoji)
+					if errReact != nil {
+						log.Printf("Error adding reaction emoji '%s' for rule '%s' (message %s): %v",
+							rule.Actions.ReactionEmoji, ruleNameLog, message.ID, errReact)
+					} else {
+						log.Printf("Successfully added reaction emoji '%s' for rule '%s' to message %s.",
+							rule.Actions.ReactionEmoji, ruleNameLog, message.ID)
+					}
+				}
+
+				// Handle emergency notification tracking if a receipt ID was returned
+				if receiptID != "" && rule.Actions.Priority == 2 && rule.Actions.Emergency != nil {
+					expiryDuration := time.Duration(rule.Actions.Emergency.Expire) * time.Second
+					if rule.Actions.Emergency.Expire <= 0 { // Ensure non-negative, non-zero expiry for tracking
+						log.Printf("Warning: Rule '%s' has emergency priority but invalid 'expire' value (%d). Using default 1 hour for internal tracking.", ruleNameLog, rule.Actions.Emergency.Expire)
+						expiryDuration = 3600 * time.Second
+					}
+					
+					trackedMsg := TrackedEmergencyMessage{
+						DiscordMessageID:  message.ID,
+						DiscordChannelID:  message.ChannelID,
+						PushoverReceiptID: receiptID,
+						AckEmoji:          rule.Actions.Emergency.AckEmoji,
+						ExpiryTime:        time.Now().Add(expiryDuration),
+					}
+					trackedMessages.Store(receiptID, trackedMsg)
+					log.Printf("Tracking emergency message for rule '%s' (Receipt: %s, DiscordMsg: %s, AckEmoji: %s, Expires: %s)",
+						ruleNameLog, receiptID, message.ID, trackedMsg.AckEmoji, trackedMsg.ExpiryTime.Format(time.RFC3339))
+				} else if receiptID != "" && rule.Actions.Priority == 2 && rule.Actions.Emergency == nil {
+					log.Printf("Warning: Rule '%s' is emergency priority but 'emergency' parameters are not defined. Cannot track acknowledgement.", ruleNameLog)
+				}
+			}
+			// Stop processing further rules for this message
+			log.Printf("Finished processing actions for matched rule '%s' on message ID %s. No further rules will be evaluated for this message.", ruleNameLog, message.ID)
+			return
+		}
+		log.Printf("Rule #%d ('%s') did not match for message ID %s.", i+1, ruleNameLog, message.ID)
+	}
+	log.Printf("No rules matched for message ID %s after evaluating all %d rules.", message.ID, len(config.Rules))
+}
+
+// checkRuleConditions evaluates all conditions for a single rule using AND logic.
+// A condition is considered "active" if its corresponding field in the config is non-zero.
+// If a condition is active, it must evaluate to true. If not active, it's skipped (effectively true).
+func checkRuleConditions(message *discordgo.MessageCreate, conditions *RuleConditions, session *discordgo.Session, ruleNameLog string) bool {
+	logPrefix := fmt.Sprintf("Rule '%s', MessageID '%s': ", ruleNameLog, message.ID)
+
+	// ChannelID condition
+	if conditions.ChannelID != "" {
+		if message.ChannelID != conditions.ChannelID {
+			log.Printf(logPrefix+"Condition failed (ChannelID): message channel %s != rule channel %s", message.ChannelID, conditions.ChannelID)
+			return false
+		}
+		log.Printf(logPrefix+"Condition passed (ChannelID): %s", conditions.ChannelID)
+	}
+
+	// MessageHasEmoji condition (checks reactions on the message)
+	if len(conditions.MessageHasEmoji) > 0 {
+		foundReaction := false
+		for _, reactionEmojiName := range conditions.MessageHasEmoji {
+			for _, reaction := range message.Reactions {
+				if reaction.Emoji.Name == reactionEmojiName {
+					foundReaction = true
+					break
+				}
+			}
+			if foundReaction { // Found one of the required emojis
+				break
+			}
+		}
+		if !foundReaction {
+			log.Printf(logPrefix+"Condition failed (MessageHasEmoji): No specified reaction emoji found. Required: %v, Present: %v", conditions.MessageHasEmoji, message.Reactions)
+			return false
+		}
+		log.Printf(logPrefix+"Condition passed (MessageHasEmoji): Found one of %v", conditions.MessageHasEmoji)
+	}
+	
+	// ContentIncludes condition (ALL keywords must be present)
+	if len(conditions.ContentIncludes) > 0 {
+		allKeywordsFound := true
+		lowerMessageContent := strings.ToLower(message.Content) // Optimize: convert message content to lower once
+		for _, keyword := range conditions.ContentIncludes {
+			if !strings.Contains(lowerMessageContent, strings.ToLower(keyword)) {
+				allKeywordsFound = false
+				log.Printf(logPrefix+"Condition failed (ContentIncludes): keyword '%s' not found in message.", keyword)
+				break
+			}
+		}
+		if !allKeywordsFound {
+			return false
+		}
+		log.Printf(logPrefix+"Condition passed (ContentIncludes): All keywords %v found.", conditions.ContentIncludes)
+	}
+
+	// Mentions conditions: ReactToAtMention and SpecificMentions
+	// These are treated as separate AND conditions if configured.
+
+	// ReactToAtMention condition
+	if conditions.ReactToAtMention {
+		botMentioned := false
+		if message.MentionsEveryone { // @everyone or @here implies bot is mentioned if it's in the channel
+			botMentioned = true
+			log.Printf(logPrefix+"ReactToAtMention: message mentions everyone/here.")
+		} else {
+			for _, user := range message.Mentions {
+				if user.ID == session.State.User.ID {
+					botMentioned = true
+					break
+				}
+			}
+		}
+		if !botMentioned {
+			log.Printf(logPrefix+"Condition failed (ReactToAtMention): Bot (ID: %s) was not mentioned.", session.State.User.ID)
+			return false
+		}
+		log.Printf(logPrefix+"Condition passed (ReactToAtMention): Bot was mentioned.")
+	}
+
+	// SpecificMentions condition
+	if len(conditions.SpecificMentions) > 0 {
+		specificMentionFound := false
+		for _, mentionID := range conditions.SpecificMentions {
+			// Check user mentions
+			for _, user := range message.Mentions {
+				if user.ID == mentionID {
+					specificMentionFound = true
+					log.Printf(logPrefix+"SpecificMentions: Found mentioned user ID %s.", mentionID)
+					break
+				}
+			}
+			if specificMentionFound {
+				break
+			}
+			// Check role mentions
+			for _, roleID := range message.MentionRoles {
+				if roleID == mentionID {
+					specificMentionFound = true
+					log.Printf(logPrefix+"SpecificMentions: Found mentioned role ID %s.", mentionID)
+					break
+				}
+			}
+			if specificMentionFound {
+				break
+			}
+		}
+		if !specificMentionFound {
+			log.Printf(logPrefix+"Condition failed (SpecificMentions): None of the specified users/roles %v were mentioned.", conditions.SpecificMentions)
+			return false
+		}
+		log.Printf(logPrefix+"Condition passed (SpecificMentions): At least one of %v was mentioned.", conditions.SpecificMentions)
+	}
+
+	// If all active conditions passed (or no conditions were active), the rule conditions are met.
+	log.Printf(logPrefix+"All active conditions passed for rule.")
+	return true
+}


### PR DESCRIPTION
This commit introduces the `discord2pushover` application, a Go-based CLI tool that monitors Discord messages and sends Pushover notifications based on your defined rules.

Key features:
- Watches for Discord messages in specified channels or all channels.
- Parses a YAML configuration file for settings and rules.
- Supports environment variable substitution in the configuration.
- Rule engine evaluates messages against conditions:
    - Discord channel ID
    - Message reactions (emojis)
    - @mentions (bot or specific users/roles)
    - Message content keywords (all keywords must match)
- Rule actions include:
    - Sending Pushover notifications with varying priorities.
    - Adding a reaction emoji to the Discord message.
- Handles Pushover emergency-priority notifications:
    - Tracks receipts for acknowledgements.
    - Polls Pushover API every 5 seconds for ack status (for up to 1 hour or configured expiry).
    - Adds a specific acknowledgement emoji to the Discord message upon successful ack.
- Graceful shutdown on SIGINT and SIGTERM.
- Comprehensive README.md detailing configuration, setup, and usage.
- Version information available via `-version` flag.